### PR TITLE
feat: import icons from figma to icons folder

### DIFF
--- a/public/assets/icons/blue-right-arrow.svg
+++ b/public/assets/icons/blue-right-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.0244 2.47485L18.899 10.3495L11.0244 18.2241" stroke="#5602E0" stroke-width="1.5"/>
+<line x1="18.899" y1="10.1995" x2="-4.84646e-05" y2="10.1995" stroke="#5602E0" stroke-width="1.5"/>
+</svg>

--- a/public/assets/icons/gray-left-arrow.svg
+++ b/public/assets/icons/gray-left-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.32446 2.47485L1.44986 10.3495L9.32446 18.2241" stroke="#9A9A9A" stroke-width="1.5"/>
+<line y1="-0.75" x2="18.899" y2="-0.75" transform="matrix(1 0 0 -1 1.44989 9.44946)" stroke="#9A9A9A" stroke-width="1.5"/>
+</svg>

--- a/public/assets/icons/left-arrow.svg
+++ b/public/assets/icons/left-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.32446 2.47485L1.44986 10.3495L9.32446 18.2241" stroke="black" stroke-width="1.5"/>
+<line y1="-0.75" x2="18.899" y2="-0.75" transform="matrix(1 0 0 -1 1.44995 9.44952)" stroke="black" stroke-width="1.5"/>
+</svg>

--- a/public/assets/icons/link-arrow.svg
+++ b/public/assets/icons/link-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="15" height="16" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.86353 1.63635H13.9999V12.7727" stroke="black" stroke-width="1.5"/>
+<line x1="13.8939" y1="1.53033" x2="0.530219" y2="14.894" stroke="black" stroke-width="1.5"/>
+</svg>

--- a/public/assets/icons/right-arrow.svg
+++ b/public/assets/icons/right-arrow.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.0244 2.47485L18.899 10.3495L11.0244 18.2241" stroke="black" stroke-width="1.5"/>
+<line x1="18.8989" y1="10.1995" x2="-0.0001095" y2="10.1995" stroke="black" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Describe your changes
we imported icons from figma to icons folder from ` /public/assets/icons/`

## Issue ticket number and link
id->006
link-> [here](https://www.notion.so/apeunit/Icons-0081382075bd47ef82637f425a495937)
## Tasks completed
- [x] imported five icons in icons folder from assets
- [x] deleted icons file
## Tasks not completed
None
## Screenshots (if needed)