### PR TITLE
feat: set the breakpoints in tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
+    screens: {
+      md: "24.375rem",
+      lg: "52.125rem",
+    },
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Describe your changes
set the breakpoints on desktop, tablet  and mobile in tailwind configuration file


## Issue ticket number and link
ID->#009
Link->[here](https://www.notion.so/apeunit/Set-breakpoints-in-tailwind-config-723e67706773420f84968ee2814fc240)


## Tasks completed

- [x] set md as 390px ( starting breakpoint of tablet screens)
- [x] set lg as 834px ( starting breakpoint of desktop screens)

## Tasks not completed
none

## Screenshots (if needed)
