### PR TITLE
feat: add sections' wrapper

### DIFF
--- a/components/layout/Wrapper.jsx
+++ b/components/layout/Wrapper.jsx
@@ -1,0 +1,5 @@
+export default function Wrapper({children}) {
+    return (
+        <div className="box-content max-w-8xl mx-auto px-5 md:px-9 lg:px-16">{children}</div>
+    )
+}

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,7 +1,11 @@
+import Wrapper from "../components/layout/Wrapper";
+
 export default function Home() {
   return (
-    <h1 className="text-4xl  text-center">
-      <span className="text-red-500"> RED!</span> coming soon
-    </h1>
+    <Wrapper>
+      <h1 className="text-4xl  text-center bg-green-200">
+        <span className="text-red-500"> RED!</span> coming soon
+      </h1>
+    </Wrapper>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,9 @@ module.exports = {
           50:'#E4E4E4', //this is light grey
           100:'#878787' //this is  grey for the tags
         }
+      },
+      maxWidth: {
+        "8xl": "82rem"
       }
     },
   },


### PR DESCRIPTION
## Describe your changes
added a wrapper component with max-width(1312px) and a horizontal padding of 64px on a desktop, 36px on a tablet, and 20px on mobile. the element Is centered  
## Issue ticket number and link
id -> 011
link -> [here](https://www.notion.so/apeunit/section-wrapper-component-a7368dfee4954f5a812bcaca5d711cea)

## Tasks completed

- [x] created a section wrapper and added it to the layout directory
- [x] gave wrapper max-width of 1312px
- [x] gave a wrapper horizontal padding of 64px on a desktop, 36px on a tablet, and 20px on mobile
- [x] we centered the wrapper(mx-auto)
## Tasks not completed
None
## Screenshots (if needed)