### PR TITLE
fix: change all breakpoints from mobile to desktop

### DIFF
--- a/components/layout/Wrapper.jsx
+++ b/components/layout/Wrapper.jsx
@@ -1,5 +1,7 @@
-export default function Wrapper({children}) {
-    return (
-        <div className="box-content max-w-8xl mx-auto px-5 sm:px-9 lg:px-16">{children}</div>
-    )
+export default function Wrapper({ children }) {
+  return (
+    <div className="box-content max-w-8xl mx-auto px-5 md:px-9 xl:px-16">
+      {children}
+    </div>
+  );
 }

--- a/components/ui/Anchor.jsx
+++ b/components/ui/Anchor.jsx
@@ -1,11 +1,24 @@
-import React from 'react'
-import Image from 'next/image'
-import linkIcon from '/public/assets/icons/link-arrow.svg'
-import Link from 'next/link'
+import React from "react";
+import Image from "next/image";
+import linkIcon from "/public/assets/icons/link-arrow.svg";
+import Link from "next/link";
 
-export default function Anchor({href, children}) {
+export default function Anchor({ href, children }) {
   return (
-        <Link href={href} className='inline-flex gap-1  sm:leading-relaxed leading-loose font-normal sm:text-2xl text-xl tracking-normal sm:tracking-wide group'><span className='relative after:absolute after:bottom-0.5 after:left-0.5 after:right-0 after:w-auto after:h-[1px] after:bg-black inline-block'>{children}</span> <Image className='group-hover:translate-x-1 group-hover:-translate-y-1 ease-out transition-transform duration-300' alt='arrow' width='14' height='14' src={linkIcon} /></Link>
-
-  )
+    <Link
+      href={href}
+      className="inline-flex gap-1  md:leading-relaxed leading-loose font-normal md:text-2xl text-xl tracking-normal md:tracking-wide group"
+    >
+      <span className="relative after:absolute after:bottom-0.5 after:left-0.5 after:right-0 after:w-auto after:h-[1px] after:bg-black inline-block">
+        {children}
+      </span>{" "}
+      <Image
+        className="group-hover:translate-x-1 group-hover:-translate-y-1 ease-out transition-transform duration-300"
+        alt="arrow"
+        width="14"
+        height="14"
+        src={linkIcon}
+      />
+    </Link>
+  );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,15 +5,15 @@
 
 @layer components {
   h1 {
-    @apply text-6xl leading-tight tracking-wider sm:text-7xl sm:leading-tighter;
+    @apply text-6xl leading-tight tracking-wider md:text-7xl md:leading-tighter;
   }
   h2 {
-    @apply text-3xl leading-normal tracking-tight sm:text-4xl sm:leading-snug;
+    @apply text-3xl leading-normal tracking-tight md:text-4xl md:leading-snug;
   }
   h3 {
-    @apply text-2xl leading-relaxed tracking-wide sm:leading-snug text-grey;
+    @apply text-2xl leading-relaxed tracking-wide md:leading-snug text-grey;
   }
   p {
-    @apply text-xl leading-loose tracking-normal sm:text-2xl sm:leading-relaxed sm:tracking-wide;
+    @apply text-xl leading-loose tracking-normal md:text-2xl md:leading-relaxed md:tracking-wide;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,11 +5,11 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-
     extend: {
       screens: {
         sm: "24.375rem",
         md: "52.125rem",
+        xl: "90rem",
       },
       fontFamily: {
         sans: ["Neufile Grotesk"], // called it sans for it to act as default


### PR DESCRIPTION
## Describe your changes
modify already created components that use the sm breakpoint so that the mobile goes from range 0-833px, and the iPad goes from 834-1023px(md) and modify xl in the tailwind configuration so that it starts at 1440px. The lg breakpoint won't change it will stay the tailwind default(1024px).
## Issue ticket number and link
id->#029
link->[here](https://www.notion.so/apeunit/fix-mobile-breakpoint-upper-bound-265a8665cc3543b19a0d1badf1e060ed)
## Tasks completed
- [x] change xl breakpoints 
- [x] modify wrapper , anchor components , titles and paragraph sm breakpoint to md
## Tasks not completed
none
## Screenshots (if needed)