### PR TITLE
feat: create hero section

### DIFF
--- a/components/sections/homepage/Hero.jsx
+++ b/components/sections/homepage/Hero.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import Wrapper from '../../layout/Wrapper'
+import Anchor from '../../ui/Anchor'
+
+export default function Hero() {
+  return (
+    <Wrapper>
+        <div className='flex flex-col gap-y-4.48 md:gap-y-5.3 lg:flex-row justify-between pt-6.75 md:pt-12 pb-8.25 md:pb-16.69 lg:pb-26 xl:pb-34   gap-x-25.25'>
+            <div ><p className='w-max'>Ape Unit</p></div>
+            <div className='xl:max-w-4xl lg:max-w-3xl '>
+              <p className='sm:hidden '>Unit➇ is a pioneering technology and marketing services company that creates end-to-end digital experiences for brands such as <span className='text-purple'> Google, Philips, Audi, Twitch, Patagonia, eBay </span>  and more. Its team of 2,500+ digital specialists across 30+ locations on 5 continents delivers pioneering work on a global scale with a boutique culture. <Anchor href='web3@apeunit.com'>Contact us</Anchor> </p>
+
+              <p className='hidden sm:block'>Unit➇ is a pioneering technology company specialing in decentralised technologies that creates end-to-end digital experiences for protocols including <span className='text-purple'> Ethereum, Tezos, Near, Algorand, Celo </span> and more. Its team of 2,500+ digital specialists across 30+ locations on 5 continents delivers pioneering work on a global scale with a boutique culture. <Anchor href='web3@apeunit.com'>Contact us</Anchor> </p>
+
+            </div>
+
+          
+        </div>
+    </Wrapper>
+  )
+}

--- a/components/sections/homepage/Hero.jsx
+++ b/components/sections/homepage/Hero.jsx
@@ -1,21 +1,40 @@
-import React from 'react'
-import Wrapper from '../../layout/Wrapper'
-import Anchor from '../../ui/Anchor'
+import React from "react";
+import Wrapper from "../../layout/Wrapper";
+import Anchor from "../../ui/Anchor";
 
 export default function Hero() {
   return (
     <Wrapper>
-        <div className='flex flex-col gap-y-4.48 md:gap-y-5.3 lg:flex-row justify-between pt-6.75 md:pt-12 pb-8.25 md:pb-16.69 lg:pb-26 xl:pb-34   gap-x-25.25'>
-            <div ><p className='w-max'>Ape Unit</p></div>
-            <div className='xl:max-w-4xl lg:max-w-3xl '>
-              <p className='sm:hidden '>Unit➇ is a pioneering technology and marketing services company that creates end-to-end digital experiences for brands such as <span className='text-purple'> Google, Philips, Audi, Twitch, Patagonia, eBay </span>  and more. Its team of 2,500+ digital specialists across 30+ locations on 5 continents delivers pioneering work on a global scale with a boutique culture. <Anchor href='web3@apeunit.com'>Contact us</Anchor> </p>
-
-              <p className='hidden sm:block'>Unit➇ is a pioneering technology company specialing in decentralised technologies that creates end-to-end digital experiences for protocols including <span className='text-purple'> Ethereum, Tezos, Near, Algorand, Celo </span> and more. Its team of 2,500+ digital specialists across 30+ locations on 5 continents delivers pioneering work on a global scale with a boutique culture. <Anchor href='web3@apeunit.com'>Contact us</Anchor> </p>
-
-            </div>
-
-          
+      <div className="flex flex-col gap-y-4.48 md:gap-y-5.3 lg:flex-row justify-between pt-6.75 md:pt-12 pb-8.25 md:pb-16.69 lg:pb-26 xl:pb-34   gap-x-25.25">
+        <div>
+          <p className="w-max">Ape Unit</p>
         </div>
+        <div className="xl:max-w-4xl lg:max-w-3xl ">
+          <p className="sm:hidden ">
+            Unit➇ is a pioneering technology and marketing services company that
+            creates end-to-end digital experiences for brands such as
+            <span className="text-purple">
+              Google, Philips, Audi, Twitch, Patagonia, eBay
+            </span>
+            and more. Its team of 2,500+ digital specialists across 30+
+            locations on 5 continents delivers pioneering work on a global scale
+            with a boutique culture.
+            <Anchor href="web3@apeunit.com">Contact us</Anchor>
+          </p>
+          <p className="hidden sm:block">
+            Unit➇ is a pioneering technology company specialing in decentralised
+            technologies that creates end-to-end digital experiences for
+            protocols including
+            <span className="text-purple">
+              Ethereum, Tezos, Near, Algorand, Celo
+            </span>
+            and more. Its team of 2,500+ digital specialists across 30+
+            locations on 5 continents delivers pioneering work on a global scale
+            with a boutique culture.
+            <Anchor href="web3@apeunit.com">Contact us</Anchor>
+          </p>
+        </div>
+      </div>
     </Wrapper>
-  )
+  );
 }

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,22 +1,9 @@
-import Tag from "../components/ui/Tag";
-import Wrapper from "../components/layout/Wrapper";
-import Anchor from "../components/ui/Anchor";
+import Hero from "../components/sections/homepage/Hero";
 
 export default function Home() {
   return (
-    <Wrapper>
-      <h1 className="text-4xl  text-center bg-green-200">
-        <span className="text-red-500"> RED!</span> coming soon
-      </h1>
-      <Anchor href="https://www.youtube.com/">Contact us</Anchor>
-      <div className="w-fit m-auto">
-        <Tag>02 Oct 2022</Tag>
-        <Tag fill>DAOs</Tag>
-      </div>
-      <h1>The quick brown fox jumps over the lazy dog</h1>
-      <h2>The quick brown fox jumps over the lazy dog</h2>
-      <h3>The quick brown fox jumps over the lazy dog</h3>
-      <p>The quick brown fox jumps over the lazy dog</p>
-    </Wrapper>
+    <main>
+      <Hero/>
+    </main>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,15 @@ module.exports = {
       },
       spacing: {
         0.6: "0.1875rem", // this is 3px
+        4.5:'1.125rem',
+        6.75:'1.6875rem' , // this is 27px
+        25.25:'6.3125rem', // 101px
+        5.30: '1.3256rem',  //21.21px
+        4.48: '1.1213rem', //17.94px
+        8.25: '2.0625rem', // 33px
+        16.69: '4.1744rem', //66px
+        26:'6.5rem', //104px
+        34:'8.5rem', //136px
       },
       borderRadius: {
         md: "1.1875rem", // this is 19px for border radius
@@ -45,7 +54,9 @@ module.exports = {
         wider: "-0.02em", //-2%
       },
       maxWidth: {
-        "8xl": "82rem",
+        "8xl": "82rem", //1312px
+        '4xl': '50.375rem',  // 806px
+        '3xl':'47.3125rem'  // 757px
       },
       fontSize: {
         "6xl": "3.5rem", // this is the size of 56px


### PR DESCRIPTION
## Describe your changes
Created a Hero component in the homepage folder, and added content. The hero section has two parts. The first on the left has only the company name, and the left part have the company description paragraph. There is space between those two parts. On mobile, the two parts are vertically aligned.
## Issue ticket number and link
ID->#014
Link->[here](https://www.notion.so/apeunit/Hero-section-695bb1d202aa42dba456753e1d2fe9f3)
## Tasks completed
- [x] Create hero component in Homepage section folder
- [x] Create two sections inside the Hero file
- [x] Align two sections vertically on mobile
- [x] Align two section Horizontally from big tablets up to big screens
- [x] Created new spacing values in Tailwind Config file 
## Tasks not completed
none
## Screenshots (if needed)