### PR TITLE
feat: add project section desktop design

### DIFF
--- a/components/layout/ProjectTitle.jsx
+++ b/components/layout/ProjectTitle.jsx
@@ -1,7 +1,0 @@
-import Link from "next/link";
-
-export default function ProjectTitle({href, children, handle, remove}) {
-
-    return <><Link onMouseEnter={handle}  href={href}><h1 onMouseLeave={remove}>{children}</h1></Link>
-    </>
-}

--- a/components/layout/ProjectTitle.jsx
+++ b/components/layout/ProjectTitle.jsx
@@ -1,0 +1,7 @@
+import Link from "next/link";
+
+export default function ProjectTitle({href, children, handle, remove}) {
+
+    return <><Link onMouseEnter={handle}  href={href}><h1 onMouseLeave={remove}>{children}</h1></Link>
+    </>
+}

--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import ProjectTitle from "../../layout/ProjectTitle";
+import ProjectTitle from "../../ui/ProjectTitle";
 import Wrapper from "../../layout/Wrapper";
 import ProjectCard from "../../ui/ProjectCard";
 import data from "../../../data/projectCard";
@@ -27,7 +27,7 @@ export default function Projects() {
     <Wrapper>
       <h3 className="mb-2.75 pl-1">Projects</h3>
       <div className="flex justify-between">
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 items-start">
           <ProjectTitle
             handle={handleHover(1)}
             remove={handleMouseOut}

--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -8,20 +8,27 @@ export default function Projects() {
   const [show, setShow] = useState();
   const handleHover = (value) => {
     return function (event) {
-            setShow(value);
- 
+      setShow(value);
     };
   };
   const handleMouseOut = async () => {
-        setShow(null);
+    setShow(null);
   };
-  const cards = data.map(el => <ProjectCard src={el.src} key={el.id} text={el.text} id={el.id} show={show} />)
+  const cards = data.map((el) => (
+    <ProjectCard
+      src={el.src}
+      key={el.id}
+      text={el.text}
+      id={el.id}
+      show={show}
+    />
+  ));
   return (
     <Wrapper>
       <h3 className="mb-2.75 pl-1">Projects</h3>
       <div className="flex justify-between">
         <div className="flex flex-col gap-2">
-        <ProjectTitle
+          <ProjectTitle
             handle={handleHover(1)}
             remove={handleMouseOut}
             show={show}

--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import ProjectTitle from "../../layout/ProjectTitle";
+import Wrapper from "../../layout/Wrapper";
+import ProjectCard from "../../ui/ProjectCard";
+import data from "../../../data/projectCard";
+
+export default function Projects() {
+  const [show, setShow] = useState();
+  const handleHover = (value) => {
+    return function (event) {
+            setShow(value);
+ 
+    };
+  };
+  const handleMouseOut = async () => {
+        setShow(null);
+  };
+  const cards = data.map(el => <ProjectCard src={el.src} key={el.id} text={el.text} id={el.id} show={show} />)
+  return (
+    <Wrapper>
+      <h3 className="mb-2.75 pl-1">Projects</h3>
+      <div className="flex justify-between">
+        <div className="flex flex-col gap-2">
+        <ProjectTitle
+            handle={handleHover(1)}
+            remove={handleMouseOut}
+            show={show}
+            href="https://dacade.org/"
+          >
+            Dacade
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(2)}
+            remove={handleMouseOut}
+            href="https://www.bitlipa.com/"
+          >
+            Bitlipa
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(3)}
+            remove={handleMouseOut}
+            href="https://www.symplifi.co/"
+          >
+            Symplifi
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(4)}
+            remove={handleMouseOut}
+            href="https://utu.io/"
+          >
+            UTU.io
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(5)}
+            remove={handleMouseOut}
+            href="https://neueux.com/apps"
+          >
+            NeueUX
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(6)}
+            remove={handleMouseOut}
+            href="/"
+          >
+            Lab3
+          </ProjectTitle>
+          <ProjectTitle
+            handle={handleHover(7)}
+            remove={handleMouseOut}
+            href="https://evenmusic.co/"
+          >
+            Even
+          </ProjectTitle>
+        </div>
+        <div className="min-w-[811px] relative">{cards}</div>
+      </div>
+    </Wrapper>
+  );
+}

--- a/components/ui/ProjectCard.jsx
+++ b/components/ui/ProjectCard.jsx
@@ -1,10 +1,13 @@
 import Image from "next/image";
-export default function ProjectCard({src, text, id, show}) {
+export default function ProjectCard({ src, text, id, show }) {
   return (
-    <div className={`absolute w-full duration-300 ease-out  transition-all ${ id === show ? "opacity-100 pt-3.5": "opacity-0 pt-3.5"}`}>
+    <div
+      className={`absolute w-full duration-300 ease-out  transition-all ${
+        id === show ? "opacity-100 pt-3.5" : "opacity-0 pt-3.5"
+      }`}
+    >
       <div className="relative h-111 w-full drop-shadow-sm rounded-xl">
         <Image
-        id="img"
           src={src}
           priority
           className="object-cover"
@@ -12,7 +15,6 @@ export default function ProjectCard({src, text, id, show}) {
           alt=""
         />
       </div>
-      
       {id === show && <p className="mt-2">{text}</p>}
     </div>
   );

--- a/components/ui/ProjectCard.jsx
+++ b/components/ui/ProjectCard.jsx
@@ -1,0 +1,19 @@
+import Image from "next/image";
+export default function ProjectCard({src, text, id, show}) {
+  return (
+    <div className={`absolute w-full duration-300 ease-out  transition-all ${ id === show ? "opacity-100 pt-3.5": "opacity-0 pt-3.5"}`}>
+      <div className="relative h-111 w-full drop-shadow-sm rounded-xl">
+        <Image
+        id="img"
+          src={src}
+          priority
+          className="object-cover"
+          fill
+          alt=""
+        />
+      </div>
+      
+      {id === show && <p className="mt-2">{text}</p>}
+    </div>
+  );
+}

--- a/components/ui/ProjectTitle.jsx
+++ b/components/ui/ProjectTitle.jsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import Image from "next/image";
+import arrow from "/public/assets/icons/link-arrow.svg";
+
+export default function ProjectTitle({ href, children, handle, remove }) {
+  return (
+    <>
+      <Link
+        onMouseOver={handle}
+        onMouseLeave={remove}
+        className="z-10 hover:after:bg-black flex items-start gap-2 group after:transition-colors after:duration-300  after:block after:absolute relative after:bottom-0.6 after:w-full after:h-0.5 after:bg-transparent   "
+        href={href}
+      >
+        <h1>{children}</h1>
+        <Image
+          alt="arrow"
+          src={arrow}
+          priority
+          width="14"
+          height="13"
+          className="pt-3 transition-opacity duration-300 inline-block opacity-0 group-hover:opacity-100"
+        />
+      </Link>
+    </>
+  );
+}

--- a/data/projectCard.js
+++ b/data/projectCard.js
@@ -1,0 +1,39 @@
+const data = [
+    {
+        id: 1,
+        src: "/assets/images/dacade.webp",
+        text: "Peer-to-Peer learning platform"
+    },
+    {
+        id: 2,
+        src: "/assets/images/bitlipa.webp",
+        text: "Cryptocurrency bitcoin Ethereum Trading App African Kenyan"
+    },
+    {
+        id: 3,
+        src: "/assets/images/symplifi.webp",
+        text: "Fintech solution providing an alternative to the global remittance market"
+    },
+    {
+        id: 4,
+        src: "/assets/images/utu.webp",
+        text: "Resources that improve design systems for web3"
+    },
+    {
+        id: 5,
+        src: "/assets/images/neueux.webp",
+        text: "Resources that improve design systems for web3"
+    },
+    {
+        id: 6,
+        src: "/assets/images/lab3.webp",
+        text: "A web3 knowledge exchange community for music makers"
+    },
+    {
+        id: 7,
+        src: "/assets/images/even.webp",
+        text: "A web3 knowledge exchange community for music makers"
+    },
+]
+
+export default data

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,22 +1,7 @@
-import Tag from "../components/ui/Tag";
-import Wrapper from "../components/layout/Wrapper";
-import Anchor from "../components/ui/Anchor";
+import Projects from "../components/sections/homepage/Projects";
 
 export default function Home() {
   return (
-    <Wrapper>
-      <h1 className="text-4xl  text-center bg-green-200">
-        <span className="text-red-500"> RED!</span> coming soon
-      </h1>
-      <Anchor href="https://www.youtube.com/">Contact us</Anchor>
-      <div className="w-fit m-auto">
-        <Tag>02 Oct 2022</Tag>
-        <Tag fill>DAOs</Tag>
-      </div>
-      <h1>The quick brown fox jumps over the lazy dog</h1>
-      <h2>The quick brown fox jumps over the lazy dog</h2>
-      <h3>The quick brown fox jumps over the lazy dog</h3>
-      <p>The quick brown fox jumps over the lazy dog</p>
-    </Wrapper>
+    <Projects />
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,12 @@ module.exports = {
       },
       spacing: {
         0.6: "0.1875rem", // this is 3px
+        2.75: "0.6875rem", // 11px
+        3.5: "0.875rem", // 14px
+        111: "27.75rem", // 444px
+      },
+      height: {
+        111: "27.75rem", // 444px
       },
       borderRadius: {
         md: "1.1875rem", // this is 19px for border radius
@@ -52,6 +58,24 @@ module.exports = {
         "7xl": "4rem", // this is the size of 64px
         "3xl": "1.75rem", // this is the size of 28px
       },
+      dropShadow: {
+        "sm": "1px 1px 14px rgba(0, 0, 0, 0.1)"
+      },
+      keyframes: {
+        "show": {
+          '0%': { opacity: 0},
+          "100%": {opacity: 1},
+        },
+        "unshow": {
+          "0%": {opacity: 1},
+          '100%': { opacity: 0},
+          
+        }
+      },
+      animation: {
+        'show': "show 300ms ease-out both",
+        'unshow': "unshow 300ms ease-out both"
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
## Describe your changes
Created a Project component. on desktop, created two sections, the first section contains the list of items in H1 style, and the second section contains the project card contains an image and text below the image; the cards will be displayed when the user hovers over the project item, respectively .
 when a user hovers on a project title, underline and arrow is added.
## Issue ticket number and link
id -> 017
link -> [here](https://www.notion.so/apeunit/projects-section-ff9553bcac9647d2ab229a7e2c110782)
## Tasks completed
- [x] add the project section desktop design
- [x] link the project title to website outside the page 
- [x] added underline and arrow effect on hover 
## Tasks not completed
none
## Screenshots (if needed)