### PR TITLE
fix: change the width  of expertise section on desktop version

### DIFF
--- a/components/sections/homepage/Expertise.jsx
+++ b/components/sections/homepage/Expertise.jsx
@@ -3,7 +3,7 @@ import Wrapper from "../../layout/Wrapper";
 export default function Expertise() {
   return (
     <Wrapper>
-      <div className="mt-21.25 mb-20.25 sm:mt-21.25 sm:mb-33 md:mt-22.87 lg:mt-25.75 md:mb-35.55 xl:mt-31.75 xl:mb-24  w-64.37 md:w-151.25  xl:w-40.37  ml-auto ">
+      <div className="mt-21.25 mb-20.25 sm:mt-21.25 sm:mb-33 md:mt-22.87 lg:mt-25.75 md:mb-35.55 xl:mt-31.75 xl:mb-24  w-64.37 md:w-151.25  xl:w-161.5  ml-auto ">
         <h3 className="pb-1.75 md:pb-6">Expertise</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-6.23 xl:gap-x-6">
           <div className="space-y-2 md:space-y-3">

--- a/components/sections/homepage/Expertise.jsx
+++ b/components/sections/homepage/Expertise.jsx
@@ -3,7 +3,7 @@ import Wrapper from "../../layout/Wrapper";
 export default function Expertise() {
   return (
     <Wrapper>
-      <div className="mt-21.25 mb-20.25 sm:mt-21.25 sm:mb-33 md:mt-22.87 lg:mt-25.75 md:mb-35.55 xl:mt-31.75 xl:mb-24  w-64.37 md:w-151.25  xl:w-1/2  ml-auto ">
+      <div className="mt-21.25 mb-20.25 sm:mt-21.25 sm:mb-33 md:mt-22.87 lg:mt-25.75 md:mb-35.55 xl:mt-31.75 xl:mb-24  w-64.37 md:w-151.25  xl:w-40.37  ml-auto ">
         <h3 className="pb-1.75 md:pb-6">Expertise</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 md:gap-x-6.23 xl:gap-x-6">
           <div className="space-y-2 md:space-y-3">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,6 +122,7 @@ module.exports = {
       width: {
         64.37: "16.0938rem", //257.5px,
         151.25: "37.8125rem", //605px
+        40.37:"40.375rem",  //646px
       },
       fontSize: {
         "6xl": "3.5rem", // this is the size of 56px

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -122,7 +122,7 @@ module.exports = {
       width: {
         64.37: "16.0938rem", //257.5px,
         151.25: "37.8125rem", //605px
-        40.37:"40.375rem",  //646px
+        161.5:"40.375rem",  //646px
       },
       fontSize: {
         "6xl": "3.5rem", // this is the size of 56px


### PR DESCRIPTION
## Describe your changes
changed the width of expertise section  on desktop and configured it in tailwindconfig 
## Issue ticket number and link
id->40
link->[here](https://www.notion.so/apeunit/Expertise-Section-Desktop-Tablet-Mobile-Issue-with-the-section-width-f6c536dcd5654ddfa675e43869dc8fb0)

## Tasks completed

- [x] changed the width from 656px to 646px( on xl breakpoint)
- [x]added width in tailwindconfig
## Tasks not completed
None
## Screenshots (if needed)