### PR TITLE
Refactor/project section titles

### DIFF
--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -32,7 +32,7 @@ export default function Projects() {
     };
   };
   const mobileCards = data.map((el) => (
-    <>
+    <div key={el.id}>
       <ProjectTitle
         handle={handleClick(el.id)}
         remove={handleMouseOut}
@@ -50,7 +50,7 @@ export default function Projects() {
           show={show}
         />
       </Link>
-    </>
+    </div>
   ));
   return (
     <Wrapper>

--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -1,18 +1,19 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import ProjectTitle from "../../ui/ProjectTitle";
 import Wrapper from "../../layout/Wrapper";
 import ProjectCard from "../../ui/ProjectCard";
 import data from "../../../data/projectCard";
 import Link from "next/link";
+import projectTitles from "../../../data/projectTitles";
 
 export default function Projects() {
   const [show, setShow] = useState();
   const handleHover = (value) => {
-    return function (event) {
+    return () => {
       setShow(value);
     };
   };
-  const handleMouseOut = async () => {
+  const handleMouseOut = () => {
     setShow(null);
   };
   const cards = data.map((el) => (
@@ -25,11 +26,11 @@ export default function Projects() {
     />
   ));
   const handleClick = (value) => {
-    return function(event) {
+    return () => {
       if (show === value) return setShow(null);
-      setShow(value)
-    }
-  }
+      setShow(value);
+    };
+  };
   const mobileCards = data.map((el) => (
     <>
       <ProjectTitle
@@ -57,57 +58,16 @@ export default function Projects() {
       {/* deskop version */}
       <div className="xl:flex hidden justify-between relative">
         <div className="flex flex-col gap-1 md:gap-6.5 items-start">
-          <ProjectTitle
-            handle={handleHover(1)}
-            remove={handleMouseOut}
-            show={show}
-            href="https://dacade.org/"
-          >
-            Dacade
-          </ProjectTitle>
-
-          <ProjectTitle
-            handle={handleHover(2)}
-            remove={handleMouseOut}
-            href="https://www.bitlipa.com/"
-          >
-            Bitlipa
-          </ProjectTitle>
-          <ProjectTitle
-            handle={handleHover(3)}
-            remove={handleMouseOut}
-            href="https://www.symplifi.co/"
-          >
-            Symplifi
-          </ProjectTitle>
-          <ProjectTitle
-            handle={handleHover(4)}
-            remove={handleMouseOut}
-            href="https://utu.io/"
-          >
-            UTU.io
-          </ProjectTitle>
-          <ProjectTitle
-            handle={handleHover(5)}
-            remove={handleMouseOut}
-            href="https://neueux.com/apps"
-          >
-            NeueUX
-          </ProjectTitle>
-          <ProjectTitle
-            handle={handleHover(6)}
-            remove={handleMouseOut}
-            href="/"
-          >
-            Lab3
-          </ProjectTitle>
-          <ProjectTitle
-            handle={handleHover(7)}
-            remove={handleMouseOut}
-            href="https://evenmusic.co/"
-          >
-            Even
-          </ProjectTitle>
+          {projectTitles.map((title, titleKey) => (
+            <ProjectTitle
+              handle={handleHover(title.index)}
+              remove={handleMouseOut}
+              href={title.link}
+              key={titleKey}
+            >
+              {title.name}
+            </ProjectTitle>
+          ))}
         </div>
         <div className="min-w-[811px]">{cards}</div>
       </div>

--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -58,12 +58,12 @@ export default function Projects() {
       {/* deskop version */}
       <div className="xl:flex hidden justify-between relative">
         <div className="flex flex-col gap-1 md:gap-6.5 items-start">
-          {projectTitles.map((title, titleKey) => (
+          {projectTitles.map((title, index) => (
             <ProjectTitle
-              handle={handleHover(title.index)}
+              handle={handleHover(index + 1)}
               remove={handleMouseOut}
               href={title.link}
-              key={titleKey}
+              key={index}
             >
               {title.name}
             </ProjectTitle>

--- a/data/projectTitles.js
+++ b/data/projectTitles.js
@@ -1,0 +1,39 @@
+const projectTitles = [
+    {
+        index: 1, 
+        link: "https://dacade.org/",
+        name: "Dacade",
+    },
+    {
+        index: 2, 
+        link: "https://www.bitlipa.com/",
+        name: "Bitlipa",
+    },
+    {
+        index: 3, 
+        link: "https://www.symplifi.co/",
+        name: "Symplifi",
+    },
+    {
+        index: 4, 
+        link: "https://dacade.org/",
+        name: "UTU.io",
+    },
+    {
+        index: 5, 
+        link: "https://neueux.com/apps",
+        name: "NeueUX",
+    },
+    {
+        index: 6, 
+        link: "/",
+        name: "Lab3",
+    },
+    {
+        index: 7, 
+        link: "https://evenmusic.co/",
+        name: "Even",
+    },
+]
+
+export default projectTitles;

--- a/data/projectTitles.js
+++ b/data/projectTitles.js
@@ -1,36 +1,29 @@
 const projectTitles = [
     {
-        index: 1, 
         link: "https://dacade.org/",
         name: "Dacade",
     },
     {
-        index: 2, 
         link: "https://www.bitlipa.com/",
         name: "Bitlipa",
     },
     {
-        index: 3, 
         link: "https://www.symplifi.co/",
         name: "Symplifi",
     },
     {
-        index: 4, 
         link: "https://dacade.org/",
         name: "UTU.io",
     },
     {
-        index: 5, 
         link: "https://neueux.com/apps",
         name: "NeueUX",
     },
     {
-        index: 6, 
         link: "/",
         name: "Lab3",
     },
     {
-        index: 7, 
         link: "https://evenmusic.co/",
         name: "Even",
     },


### PR DESCRIPTION
## Describe your changes
- remove unused imports in the project section component
- The `ProjectTitle` component is repeated seven times in the project section and the repetition is close together, it should be looped through once and avoid repetition.
- The `event` is not being used, you can remove it.
- the async is not being used on variable `handleMouseOut`, you can remove it and keep the same format if it is es6 or es5
## Issue ticket number and link

## Tasks completed

- [x] remove unused imports in the project section component
- [x] The `ProjectTitle` component is repeated seven times in the project section and the repetition is close together, it should be looped through once and avoid repetition.
- [x] The `event` is not being used, you can remove it.
- [x] The async is not being used on variable `handleMouseOut`, you can remove it and keep the same format if it is es6 or es5


## Tasks not completed

- none

## Screenshots (if needed)
