### PR TITLE
fix: save mouse coordinates without subtracting the width of the image

### DIFF
--- a/components/sections/homepage/Gallery.jsx
+++ b/components/sections/homepage/Gallery.jsx
@@ -20,31 +20,31 @@ export default function Gallery() {
         .map((_, i) => refs[i] || createRef())
     );
   }, []);
+
+  const getX = (x, width, container) => {
+    let newValue = x - width / 2;
+    if (newValue < 0) {
+      newValue = 0;
+    } else if (x + width >= container) {
+      newValue = container - width;
+    }
+    return newValue;
+  };
+  const getY = (y, height, container) => {
+    let newValue = y - height / 2;
+    if (y < 0) {
+      newValue = 0;
+    } else if (y + height >= container) {
+      newValue = container - height;
+    }
+    return newValue;
+  };
+
   const handleMouse = (event) => {
     const randomNumber = Math.floor(Math.random() * images.length);
     if (coordinates.length < 1) {
-      let x = event.evt.offsetX - images[randomNumber].current.clientWidth / 2;
-      let y = event.evt.offsetY - images[randomNumber].current.clientHeight / 2;
-      if (x < 0) {
-        x = 2;
-      } else if (
-        x + images[randomNumber].current.clientWidth >=
-        event.currentTarget.attrs.container.clientWidth
-      ) {
-        x =
-          event.currentTarget.attrs.container.clientWidth -
-          images[randomNumber].current.clientWidth;
-      }
-      if (y < 0) {
-        y = 0;
-      } else if (
-        y + images[randomNumber].current.clientHeight >=
-        event.currentTarget.attrs.container.clientHeight
-      ) {
-        y =
-          event.currentTarget.attrs.container.clientHeight -
-          images[randomNumber].current.clientHeight;
-      }
+      let x = event.evt.offsetX;
+      let y = event.evt.offsetY;
       setCoordinates([
         ...coordinates,
         {
@@ -53,46 +53,21 @@ export default function Gallery() {
           img: images[randomNumber],
           w: images[randomNumber].current.clientWidth,
           h: images[randomNumber].current.clientHeight,
+          containerWidth: event.currentTarget.attrs.container.clientWidth,
+          containerHeight: event.currentTarget.attrs.container.clientHeight,
           first: true,
         },
       ]);
     } else {
       if (
-        Math.abs(
-          event.evt.offsetX -
-            images[randomNumber].current.clientWidth / 2 -
-            coordinates[coordinates.length - 1].x
-        ) > 100 ||
-        Math.abs(
-          event.evt.offsetY -
-            images[randomNumber].current.clientHeight / 2 -
-            coordinates[coordinates.length - 1].y
-        ) > 100
+        Math.abs(event.evt.offsetX - coordinates[coordinates.length - 1].x) >
+          100 ||
+        Math.abs(event.evt.offsetY - coordinates[coordinates.length - 1].y) >
+          100
       ) {
-        let x =
-          event.evt.offsetX - images[randomNumber].current.clientWidth / 2;
-        let y =
-          event.evt.offsetY - images[randomNumber].current.clientHeight / 2;
-        if (x < 0) {
-          x = 2;
-        } else if (
-          x + images[randomNumber].current.clientWidth >=
-          event.currentTarget.attrs.container.clientWidth 
-        ) {
-          x =
-            event.currentTarget.attrs.container.clientWidth -
-            images[randomNumber].current.clientWidth;
-        }
-        if (y < 0) {
-          y = 0;
-        } else if (
-          y + images[randomNumber].current.clientHeight >=
-          event.currentTarget.attrs.container.clientHeight
-        ) {
-          y =
-            event.currentTarget.attrs.container.clientHeight -
-            images[randomNumber].current.clientHeight;
-        }
+        let x = event.evt.offsetX;
+        let y = event.evt.offsetY;
+
         setCoordinates([
           ...coordinates.slice(0, coordinates.length - 1),
           { ...coordinates[coordinates.length - 1], first: false, img: null },
@@ -102,6 +77,8 @@ export default function Gallery() {
             img: images[randomNumber],
             w: images[randomNumber].current.clientWidth,
             h: images[randomNumber].current.clientHeight,
+            containerWidth: event.currentTarget.attrs.container.clientWidth,
+            containerHeight: event.currentTarget.attrs.container.clientHeight,
             first: true,
           },
         ]);
@@ -110,16 +87,18 @@ export default function Gallery() {
   };
   return (
     <Wrapper>
-    <Canvas
-      container={container}
-      dimension={dimension}
-      handleMouse={handleMouse}
-      coordinates={coordinates}
-      mobileContainer={mobileContainer}
-      mobileDimension={mobileDimension}
-     />
+      <Canvas
+        container={container}
+        dimension={dimension}
+        getX={getX}
+        getY={getY}
+        handleMouse={handleMouse}
+        coordinates={coordinates}
+        mobileContainer={mobileContainer}
+        mobileDimension={mobileDimension}
+      />
       <div className="h-0 overflow-hidden">
-      {/* disabled nextjs Image component eslint to use the normal html tag */}
+        {/* disabled nextjs Image component eslint to use the normal html tag */}
         {imagesUrl.map((url, index) => {
           return (
             <img

--- a/components/ui/Canvas.jsx
+++ b/components/ui/Canvas.jsx
@@ -3,6 +3,8 @@ export default function Canvas({
   coordinates,
   dimension,
   handleMouse,
+  getX,
+  getY,
   container,
   mobileContainer,
   mobileDimension,
@@ -19,8 +21,8 @@ export default function Canvas({
                     key={index}
                     image={el.img.current}
                     alt=" "
-                    x={el.x}
-                    y={el.y}
+                    x={getX(el.x, el.w, el.containerWidth)}
+                    y={getX(el.y, el.h, el.containerHeight)}
                     width={el.w}
                     height={el.h}
                   />
@@ -28,8 +30,8 @@ export default function Canvas({
                   <Rect
                     key={index}
                     fill="#E4E4E4"
-                    x={el.x}
-                    y={el.y}
+                    x={getX(el.x, el.w, el.containerWidth)}
+                    y={getX(el.y, el.h, el.containerHeight)}
                     width={el.w}
                     height={el.h}
                   />


### PR DESCRIPTION
## Describe your changes
The image is added on the edges too many times in the gallery section. When the mouse moves on it, it adds an image without using the correct calculation, which causes it to append a lot of images at the same time.
## Issue ticket number and link
id->#53
link->[here](https://www.notion.so/apeunit/Gallery-Section-Device-All-Images-appending-to-fast-on-edge-sides-5b49bb7b0eaf458a95baddb443c87688)
## Tasks completed
- [x]  Save mouse coordinates without subtracting the width of the image 
## Tasks not completed
none
## Screenshots (if needed)