### PR TITLE
fix: Add missing Link on paragraph, Hiring Tab

### DIFF
--- a/components/sections/homepage/About.jsx
+++ b/components/sections/homepage/About.jsx
@@ -50,13 +50,20 @@ export default function About() {
                       </Anchor>
                     </p>
                   )}
-                  <p
-                    className={`${
-                      element.paragraphy1 === null ? "" : "md:pt-7.5 lg:pt-7"
-                    }`}
-                  >
-                    {element.paragraphy2}
-                  </p>
+                  {element.paragraphy1 !== null ? (
+                    <p 
+                    className="md:pt-7.5 lg:pt-7"
+                    >
+                     {element.paragraphy2}
+                    </p>
+                  ):(
+                    <p>
+                      {element.paragraphy2}
+                      <Anchor href="https://medium.com/@moritzfelipe/blockchain-the-internet-for-cooperation-37a606bb3c0">
+                        more
+                      </Anchor>
+                    </p>
+                  )}
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## Describe your changes
Add the missing Link to the paragraph on the about section, Hiring Tab 

## Issue ticket number and link
id -> 046
link -> [link](https://www.notion.so/apeunit/fix-bugs-in-about-section-link-tag-ed2e3fcc109d49bcbf8ee0c1c11b37d6)


## Tasks completed

- [x] I have Added the missing Link to the Paragraph 



## Tasks not completed

None

## Screenshots (if needed)


