### PR TITLE
fix: allow scroll when the gallery is filled with images on mobile

### DIFF
--- a/components/sections/homepage/Gallery.jsx
+++ b/components/sections/homepage/Gallery.jsx
@@ -21,56 +21,14 @@ export default function Gallery() {
     );
   }, []);
 
-  const getX = (x, width, container) => {
-    let newValue = x - width / 2;
-    if (newValue < 0) {
-      newValue = 0;
-    } else if (x + width >= container) {
-      newValue = container - width;
-    }
-    return newValue;
-  };
-  const getY = (y, height, container) => {
-    let newValue = y - height / 2;
-    if (y < 0) {
-      newValue = 0;
-    } else if (y + height >= container) {
-      newValue = container - height;
-    }
-    return newValue;
-  };
-
-  const handleMouse = (event) => {
-    const randomNumber = Math.floor(Math.random() * images.length);
-    if (coordinates.length < 1) {
-      let x = event.evt.offsetX;
-      let y = event.evt.offsetY;
-      setCoordinates([
-        ...coordinates,
-        {
-          x,
-          y,
-          img: images[randomNumber],
-          w: images[randomNumber].current.clientWidth,
-          h: images[randomNumber].current.clientHeight,
-          containerWidth: event.currentTarget.attrs.container.clientWidth,
-          containerHeight: event.currentTarget.attrs.container.clientHeight,
-          first: true,
-        },
-      ]);
-    } else {
-      if (
-        Math.abs(event.evt.offsetX - coordinates[coordinates.length - 1].x) >
-          100 ||
-        Math.abs(event.evt.offsetY - coordinates[coordinates.length - 1].y) >
-          100
-      ) {
+  const createEventHandler = (distance) => {
+    return (event) => {
+      const randomNumber = Math.floor(Math.random() * images.length);
+      if (coordinates.length < 1) {
         let x = event.evt.offsetX;
         let y = event.evt.offsetY;
-
         setCoordinates([
-          ...coordinates.slice(0, coordinates.length - 1),
-          { ...coordinates[coordinates.length - 1], first: false, img: null },
+          ...coordinates,
           {
             x,
             y,
@@ -82,17 +40,41 @@ export default function Gallery() {
             first: true,
           },
         ]);
+      } else {
+        if (
+          Math.abs(event.evt.offsetX - coordinates[coordinates.length - 1].x) >
+            distance ||
+          Math.abs(event.evt.offsetY - coordinates[coordinates.length - 1].y) >
+            distance
+        ) {
+          let x = event.evt.offsetX;
+          let y = event.evt.offsetY;
+
+          setCoordinates([
+            ...coordinates.slice(0, coordinates.length - 1),
+            { ...coordinates[coordinates.length - 1], first: false, img: null },
+            {
+              x,
+              y,
+              img: images[randomNumber],
+              w: images[randomNumber].current.clientWidth,
+              h: images[randomNumber].current.clientHeight,
+              containerWidth: event.currentTarget.attrs.container.clientWidth,
+              containerHeight: event.currentTarget.attrs.container.clientHeight,
+              first: true,
+            },
+          ]);
+        }
       }
-    }
+    };
   };
+
   return (
     <Wrapper>
       <Canvas
         container={container}
         dimension={dimension}
-        getX={getX}
-        getY={getY}
-        handleMouse={handleMouse}
+        createEventHandler={createEventHandler}
         coordinates={coordinates}
         mobileContainer={mobileContainer}
         mobileDimension={mobileDimension}
@@ -103,7 +85,7 @@ export default function Gallery() {
           return (
             <img
               ref={images[index]}
-              className="max-h-72"
+              className="max-h-60 xl:max-h-72"
               src={url}
               key={index}
               alt=""

--- a/components/ui/Canvas.jsx
+++ b/components/ui/Canvas.jsx
@@ -1,19 +1,35 @@
-import { Stage, Layer, Image, Rect } from "react-konva";
+import { Stage, Layer, Image, Rect, Text } from "react-konva";
 export default function Canvas({
   coordinates,
   dimension,
-  handleMouse,
-  getX,
-  getY,
+  createEventHandler,
   container,
   mobileContainer,
   mobileDimension,
 }) {
+  const getX = (x, width, container) => {
+    let newValue = x - width / 2;
+    if (newValue < 0) {
+      newValue = 0;
+    } else if (x + width >= container) {
+      newValue = container - width;
+    }
+    return newValue;
+  };
+  const getY = (y, height, container) => {
+    let newValue = y - height / 2;
+    if (y < 0) {
+      newValue = 0;
+    } else if (y + height >= container) {
+      newValue = container - height;
+    }
+    return newValue;
+  };
   return (
     <>
       <div ref={container} className="hidden lg:block">
         {!!dimension && (
-          <Stage width={dimension} height={856} onMouseMove={handleMouse}>
+          <Stage width={dimension} height={856} onMouseMove={createEventHandler(100)}>
             <Layer>
               {coordinates.map((el, index) => {
                 return el.first ? (
@@ -41,29 +57,32 @@ export default function Canvas({
           </Stage>
         )}
       </div>
-      <div ref={mobileContainer} className="block lg:hidden">
+      <div ref={mobileContainer} className="block lg:hidden relative">
+        <div className="absolute flex w-full h-full justify-center items-center "><p className="text-grey">Tap anywhere to see more of us</p></div>
         {!!mobileDimension && (
-          <Stage width={mobileDimension} height={856} onClick={handleMouse}>
-            <Layer>
+          <Stage width={mobileDimension} height={856} onMouseMove={createEventHandler(3)} preventDefault={false}>
+          <Layer>
               {coordinates.map((el, index) => {
                 return el.first ? (
                   <Image
                     key={index}
                     image={el.img.current}
                     alt=" "
-                    x={el.x}
-                    y={el.y}
+                    x={getX(el.x, el.w, el.containerWidth)}
+                    y={getX(el.y, el.h, el.containerHeight)}
                     width={el.w}
                     height={el.h}
+                    preventDefault={false}
                   />
                 ) : (
                   <Rect
                     key={index}
                     fill="#E4E4E4"
-                    x={el.x}
-                    y={el.y}
+                    x={getX(el.x, el.w, el.containerWidth)}
+                    y={getX(el.y, el.h, el.containerHeight)}
                     width={el.w}
                     height={el.h}
+                    preventDefault={false}
                   />
                 );
               })}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -116,6 +116,10 @@ module.exports = {
         112: "28rem", //448px
         "4xl": "50.375rem", // 806px
         "8xl": "82rem", //1312px
+        "60": "15rem", // 240px
+      },
+      maxHeight: {
+        "60": "15rem", // 240px
       },
       minWidth: {
         sm: "18.875rem", //302px


### PR DESCRIPTION
## Describe your changes
 allow scroll when the gallery is filled with images on mobile
## Issue ticket number and link
id -> #054
link -> [here](https://www.notion.so/apeunit/Tablet-IPad-Mobile-change-mouse-event-to-click-event-e8897a06ad0d40c7bd7d672d2e19d027)

## Tasks completed
- [x] Added text on the gallery section on mobile.
- [x]  responsiveness of the gallery section 
## Tasks not completed
none
## Screenshots (if needed)