### PR TITLE
fix: remove mouseout event on desktop

### DIFF
--- a/components/sections/homepage/Projects.jsx
+++ b/components/sections/homepage/Projects.jsx
@@ -61,7 +61,6 @@ export default function Projects() {
           {projectTitles.map((title, index) => (
             <ProjectTitle
               handle={handleHover(index + 1)}
-              remove={handleMouseOut}
               href={title.link}
               key={index}
             >


### PR DESCRIPTION
## Describe your changes
remove the mouseout event handler on desktop so that the project image card stays on screen when the user moves the mouse off the project title
## Issue ticket number and link
id -> #058
link -> [here](https://www.notion.so/apeunit/The-project-card-behaviour-on-the-Project-title-hover-event-f0b1a1151abe49e3be6fdb0593303e6f)
## Tasks completed
- [x] remove mouseout handler on desktop
## Tasks not completed
None
## Screenshots (if needed)
