### PR TITLE
fix: add a window resize event handler

### DIFF
--- a/components/sections/homepage/Gallery.jsx
+++ b/components/sections/homepage/Gallery.jsx
@@ -14,11 +14,19 @@ export default function Gallery() {
   useEffect(() => {
     setDimension(container.current.clientWidth);
     setMobileDimension(mobileContainer.current.clientWidth);
+    const HandleResize = () => {
+      setDimension(container.current.clientWidth);
+      setMobileDimension(mobileContainer.current.clientWidth);
+    }
+    window.addEventListener("resize", HandleResize)
     setImages((refs) =>
       Array(imagesUrl.length)
         .fill()
         .map((_, i) => refs[i] || createRef())
     );
+    return () => {
+      window.removeEventListener('resize', HandleResize)
+    }
   }, []);
 
   const createEventHandler = (distance) => {


### PR DESCRIPTION
## Describe your changes
 add a window resize event handler to track the width of the canvas container so that the canvas width is dynamic

## Issue ticket number and link
id -> 059
link -> [here](https://www.notion.so/apeunit/all-gallery-canvas-width-e0a1c42eb4324f6ab79085ec50f8f269)

## Tasks completed

- [x] add the resize event handler when the page load
- [x] remove the resize event handler when the page unloads


## Tasks not completed
None
## Screenshots (if needed)
